### PR TITLE
Add Statement Preparation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,59 @@
+package sqlair
+
+import "fmt"
+
+// ErrTypeNameNotUnique is an error indicating that the objects
+// passed as arguments to statement preparation do not constitute
+// a list of unique type names.
+type ErrTypeNameNotUnique struct {
+	name string
+}
+
+// NewErrTypeNameNotUnique returns a new error
+// for the input non-unique type name.
+func NewErrTypeNameNotUnique(name string) error {
+	return &ErrTypeNameNotUnique{name: name}
+}
+
+// Error implements error, returning a message indicating the non-unique type.
+func (e *ErrTypeNameNotUnique) Error() string {
+	return fmt.Sprintf("names for supplied types are not unique; %q is ambiguous", e.name)
+}
+
+// ErrTypeInfoNotPresent is an error indicating that the one of the
+// names used in a DSL statement, for input or output type mapping,
+// does not have associated type information.
+type ErrTypeInfoNotPresent struct {
+	name string
+}
+
+// NewErrTypeInfoNotPresent returns a new error
+// for the input type without associated info.
+func NewErrTypeInfoNotPresent(name string) error {
+	return &ErrTypeInfoNotPresent{name: name}
+}
+
+// Error implements error, returning a message
+// indicating the unrepresented identity.
+func (e *ErrTypeInfoNotPresent) Error() string {
+	return fmt.Sprintf("identity %q has no associated object from which to derive type information", e.name)
+}
+
+// ErrSuperfluousType is an error indicating that an object was supplied as an
+// argument to Prepare, but its type information is not reflected in the
+// parsed expression, making it redundant.
+type ErrSuperfluousType struct {
+	name string
+}
+
+// NewErrSuperfluousType returns a new error
+// for the input redundant type name.
+func NewErrSuperfluousType(name string) error {
+	return &ErrSuperfluousType{name: name}
+}
+
+// Error implements error, returning a message
+// indicating the redundant identity.
+func (e *ErrSuperfluousType) Error() string {
+	return fmt.Sprintf("type with name %q was supplied, but is not used in the statement", e.name)
+}

--- a/parse/ast.go
+++ b/parse/ast.go
@@ -56,7 +56,8 @@ type Expression interface {
 }
 
 // Walk recursively iterates depth-first over the input expression tree,
-// calling the input function. If it returns false, the iteration terminates.
+// calling the input function for each visited expression.
+// If it returns false, the iteration terminates.
 func Walk(parent Expression, visit func(Expression) bool) bool {
 	if !visit(parent) {
 		return false

--- a/parse/ast_test.go
+++ b/parse/ast_test.go
@@ -1,46 +1,49 @@
-package parse
+// Package parse_test is used to avoid an import loop.
+// The testing package imports parse.
+package parse_test
 
 import (
 	"testing"
 
+	"github.com/canonical/sqlair/parse"
 	sqlairtesting "github.com/canonical/sqlair/testing"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWalk(t *testing.T) {
 	expr := &sqlairtesting.SimpleExpression{
-		T: SQL,
+		T: parse.SQL,
 		E: []*sqlairtesting.SimpleExpression{
 			{
-				T: InputSource,
+				T: parse.InputSource,
 				E: []*sqlairtesting.SimpleExpression{
 					{
-						T: PassThrough,
+						T: parse.PassThrough,
 					},
 				},
 			},
 			{
-				T: Identity,
+				T: parse.Identity,
 			},
 			{
-				T: GroupedColumns,
+				T: parse.GroupedColumns,
 			},
 		},
 	}
 
-	var types []ExpressionType
-	visit := func(e Expression) bool {
-		if e.Type() == Identity {
+	var types []parse.ExpressionType
+	visit := func(e parse.Expression) bool {
+		if e.Type() == parse.Identity {
 			return false
 		}
 		types = append(types, e.Type())
 		return true
 	}
 
-	finished := Walk(expr, visit)
+	finished := parse.Walk(expr, visit)
 
 	// We expect to descend depth first into the expression tree,
 	// and stop at the `Identity` expression.
 	assert.False(t, finished)
-	assert.Equal(t, []ExpressionType{SQL, InputSource, PassThrough}, types)
+	assert.Equal(t, []parse.ExpressionType{parse.SQL, parse.InputSource, parse.PassThrough}, types)
 }

--- a/parse/ast_test.go
+++ b/parse/ast_test.go
@@ -3,43 +3,27 @@ package parse
 import (
 	"testing"
 
+	sqlairtesting "github.com/canonical/sqlair/testing"
 	"github.com/stretchr/testify/assert"
 )
 
-// testExp is a minimal implementation of Expression.
-type testExp struct {
-	t ExpressionType
-	e []*testExp
-}
-
-func (e *testExp) Type() ExpressionType { return e.t }
-func (e *testExp) String() string       { return "" }
-
-func (e *testExp) Expressions() []Expression {
-	res := make([]Expression, len(e.e))
-	for i, exp := range e.e {
-		res[i] = exp
-	}
-	return res
-}
-
 func TestWalk(t *testing.T) {
-	expr := &testExp{
-		t: SQL,
-		e: []*testExp{
+	expr := &sqlairtesting.SimpleExpression{
+		T: SQL,
+		E: []*sqlairtesting.SimpleExpression{
 			{
-				t: InputSource,
-				e: []*testExp{
+				T: InputSource,
+				E: []*sqlairtesting.SimpleExpression{
 					{
-						t: PassThrough,
+						T: PassThrough,
 					},
 				},
 			},
 			{
-				t: Identity,
+				T: Identity,
 			},
 			{
-				t: GroupedColumns,
+				T: GroupedColumns,
 			},
 		},
 	}

--- a/reflect/cache.go
+++ b/reflect/cache.go
@@ -12,12 +12,12 @@ import (
 // information for use in parsing and executing Sqlair DSL statements.
 type cache struct {
 	mutex sync.RWMutex
-	cache map[reflect.Type]Kind
+	cache map[reflect.Type]Info
 }
 
 // Reflect will return the Info of a given type,
 // generating and caching as required.
-func (r *cache) Reflect(value any) (Kind, error) {
+func (r *cache) Reflect(value any) (Info, error) {
 	v := reflect.ValueOf(value)
 	v = reflect.Indirect(v)
 
@@ -38,7 +38,7 @@ func (r *cache) Reflect(value any) (Kind, error) {
 
 // generate produces and returns reflection information for the input
 // reflect.Value that is specifically required for Sqlair operation.
-func generate(value reflect.Value) (Kind, error) {
+func generate(value reflect.Value) (Info, error) {
 	// Dereference the pointer if it is one.
 	value = reflect.Indirect(value)
 
@@ -49,7 +49,6 @@ func generate(value reflect.Value) (Kind, error) {
 	}
 
 	info := Struct{
-		Name:   value.Type().Name(),
 		Fields: make(map[string]Field),
 		value:  value,
 	}

--- a/reflect/cache_test.go
+++ b/reflect/cache_test.go
@@ -27,6 +27,7 @@ func TestReflectSimpleConcurrent(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, reflect.Int64, info.Kind())
+	assert.Equal(t, "int64", info.Name())
 
 	_, ok := info.(Value)
 	assert.True(t, ok)
@@ -51,6 +52,7 @@ func TestReflectStruct(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, reflect.Struct, info.Kind())
+	assert.Equal(t, "something", info.Name())
 
 	st, ok := info.(Struct)
 	assert.True(t, ok)

--- a/reflect/info.go
+++ b/reflect/info.go
@@ -4,13 +4,14 @@ import (
 	"reflect"
 )
 
-// Kind describes the ability to return the reflect.Kind of the receiver.
-type Kind interface {
+// Info describes the ability to return reflection information.
+type Info interface {
+	Name() string
 	Kind() reflect.Kind
 }
 
 // Value represents reflection information for a simple type.
-// It wraps a reflect.Value in order to implement Kind.
+// It wraps a reflect.Value in order to implement Info.
 type Value struct {
 	value reflect.Value
 }
@@ -20,29 +21,38 @@ func (r Value) Kind() reflect.Kind {
 	return r.value.Kind()
 }
 
+// Name returns the name of the Value's type.
+func (r Value) Name() string {
+	return r.value.Type().Name()
+}
+
 // Field represents a single field from a struct type.
 type Field struct {
+	value reflect.Value
+
 	// Name is the name of the struct field.
 	Name string
 
 	// OmitEmpty is true when "omitempty" is
 	// a property of the field's "db" tag.
 	OmitEmpty bool
-	value     reflect.Value
 }
 
 // Struct represents reflected information about a struct type.
 type Struct struct {
-	// Name is the name of the struct's type.
-	Name string
+	value reflect.Value
 
 	// Fields maps "db" tags to struct fields.
 	// Sqlair does not care about fields without a "db" tag.
 	Fields map[string]Field
-	value  reflect.Value
 }
 
 // Kind returns the Struct's reflect.Kind.
 func (r Struct) Kind() reflect.Kind {
 	return r.value.Kind()
+}
+
+// Name returns the name of the Struct's type.
+func (r Struct) Name() string {
+	return r.value.Type().Name()
 }

--- a/reflect/singleton.go
+++ b/reflect/singleton.go
@@ -15,7 +15,7 @@ var (
 func Cache() *cache {
 	once.Do(func() {
 		singleCache = &cache{
-			cache: make(map[reflect.Type]Kind),
+			cache: make(map[reflect.Type]Info),
 		}
 	})
 

--- a/statement.go
+++ b/statement.go
@@ -1,0 +1,37 @@
+package sqlair
+
+import (
+	"github.com/canonical/sqlair/parse"
+	sqlairreflect "github.com/canonical/sqlair/reflect"
+)
+
+// Statement represents a prepared Sqlair DSL statement
+// that can be executed by the database.
+type Statement struct {
+}
+
+// Prepare accepts a raw DSL string and optionally,
+// objects from which to infer type information.
+// - The string is parsed.
+// - Any input objects have their reflection information retrieved/generated.
+// - The reflection information is matched with the parser output to generate
+//   a Statement that can be passed to the database for execution.
+func Prepare(stmt string, args ...any) (*Statement, error) {
+	lex := parse.NewLexer(stmt)
+	parser := parse.NewParser(lex)
+
+	exp, err := parser.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	reflected := make([]sqlairreflect.Kind, len(args))
+	c := sqlairreflect.Cache()
+	for i, arg := range args {
+		if reflected[i], err = c.Reflect(arg); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
+}

--- a/statement.go
+++ b/statement.go
@@ -5,9 +5,9 @@ import (
 	sqlairreflect "github.com/canonical/sqlair/reflect"
 )
 
-// types is a convenience type alias for reflection
+// typeMap is a convenience type alias for reflection
 // information indexed by type name.
-type types = map[string]sqlairreflect.Info
+type typeMap = map[string]sqlairreflect.Info
 
 // Statement represents a prepared Sqlair DSL statement
 // that can be executed by the database.
@@ -16,7 +16,7 @@ type Statement struct {
 	expression parse.Expression
 
 	// argTypes holds the reflection info for types used in this statement.
-	argTypes types
+	argTypes typeMap
 }
 
 // Prepare accepts a raw DSL string and optionally,
@@ -66,9 +66,9 @@ func Prepare(stmt string, args ...any) (*Statement, error) {
 //         ON p.manager_id = m.id
 //      WHERE p.name = 'Fred'`, Person{}, Manager{})
 //
-func typesForStatement(args []any) (types, error) {
+func typesForStatement(args []any) (typeMap, error) {
 	c := sqlairreflect.Cache()
-	argTypes := make(types)
+	argTypes := make(typeMap)
 
 	for _, arg := range args {
 		reflected, err := c.Reflect(arg)
@@ -90,7 +90,7 @@ func typesForStatement(args []any) (types, error) {
 // validateExpressionTypes walks the input expression tree to ensure:
 // - Each input/output target in expression has type information in argTypes.
 // - All type information is actually required by the input/output targets.
-func validateExpressionTypes(statementExp parse.Expression, argTypes types) error {
+func validateExpressionTypes(statementExp parse.Expression, argTypes typeMap) error {
 	var err error
 	seen := make(map[string]bool)
 

--- a/statement.go
+++ b/statement.go
@@ -5,14 +5,23 @@ import (
 	sqlairreflect "github.com/canonical/sqlair/reflect"
 )
 
+// types is a convenience type alias for reflection
+// information indexed by type name.
+type types = map[string]sqlairreflect.Info
+
 // Statement represents a prepared Sqlair DSL statement
 // that can be executed by the database.
 type Statement struct {
+	// expression is the parsed expression tree for this statement.
+	expression parse.Expression
+
+	// argTypes holds the reflection info for types used in this statement.
+	argTypes types
 }
 
 // Prepare accepts a raw DSL string and optionally,
 // objects from which to infer type information.
-// - The string is parsed.
+// - The string is parsed into an expression tree.
 // - Any input objects have their reflection information retrieved/generated.
 // - The reflection information is matched with the parser output to generate
 //   a Statement that can be passed to the database for execution.
@@ -25,13 +34,97 @@ func Prepare(stmt string, args ...any) (*Statement, error) {
 		return nil, err
 	}
 
-	reflected := make([]sqlairreflect.Kind, len(args))
+	argTypes, err := typesForStatement(args)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateExpressionTypes(exp, argTypes); err != nil {
+		return nil, err
+	}
+
+	return &Statement{
+		expression: exp,
+		argTypes:   argTypes,
+	}, nil
+}
+
+// typesForStatement returns reflection information for the input arguments.
+// The reflected type name of each argument must be unique in the list,
+// which means declaring new local types to avoid ambiguity.
+//
+// Example:
+//
+//     type Person struct{}
+//     type Manager Person
+//
+//     stmt, err := sqlair.Prepare(`
+//     SELECT p.* AS &Person.*,
+//            m.* AS &Manager.*
+//       FROM person AS p
+//       JOIN person AS m
+//         ON p.manager_id = m.id
+//      WHERE p.name = 'Fred'`, Person{}, Manager{})
+//
+func typesForStatement(args []any) (types, error) {
 	c := sqlairreflect.Cache()
-	for i, arg := range args {
-		if reflected[i], err = c.Reflect(arg); err != nil {
+	argTypes := make(types)
+
+	for _, arg := range args {
+		reflected, err := c.Reflect(arg)
+		if err != nil {
 			return nil, err
+		}
+
+		name := reflected.Name()
+		if _, ok := argTypes[name]; ok {
+			return nil, NewErrTypeNameNotUnique(name)
+		}
+
+		argTypes[name] = reflected
+	}
+
+	return argTypes, nil
+}
+
+// validateExpressionTypes walks the input expression tree to ensure:
+// - Each input/output target in expression has type information in argTypes.
+// - All type information is actually required by the input/output targets.
+func validateExpressionTypes(statementExp parse.Expression, argTypes types) error {
+	var err error
+	seen := make(map[string]bool)
+
+	visit := func(exp parse.Expression) bool {
+		if t := exp.Type(); t != parse.OutputTarget && t != parse.InputSource {
+			return true
+		}
+
+		// Select the first identity, such as "Person"
+		// in the case of "$Person.id".
+		// Ensure that there is type information for it.
+		typeName := exp.Expressions()[1].String()
+		if _, ok := argTypes[typeName]; !ok {
+			err = NewErrTypeInfoNotPresent(typeName)
+			return false
+		}
+
+		seen[typeName] = true
+		return true
+	}
+
+	// If we did not complete the walk through the tree,
+	// return the error that we encountered.
+	if !parse.Walk(statementExp, visit) {
+		return err
+	}
+
+	// Now compare the type names that we saw against what we have information
+	// for. If unused types were supplied, it is an error condition.
+	for name := range argTypes {
+		if _, ok := seen[name]; !ok {
+			return NewErrSuperfluousType(name)
 		}
 	}
 
-	return nil, nil
+	return nil
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,0 +1,1 @@
+package sqlair

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,1 +1,84 @@
 package sqlair
+
+import (
+	"testing"
+
+	"github.com/canonical/sqlair/parse"
+	sqlairtesting "github.com/canonical/sqlair/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypesForStatementUniqueNames(t *testing.T) {
+	type DifferentPerson struct{}
+
+	argTypes, err := typesForStatement([]any{DifferentPerson{}, sqlairtesting.Person{}})
+	assert.Nil(t, err)
+
+	assert.Len(t, argTypes, 2)
+	assert.Equal(t, argTypes["DifferentPerson"].Name(), "DifferentPerson")
+	assert.Equal(t, argTypes["Person"].Name(), "Person")
+}
+
+func TestTypesForStatementDuplicateNamesError(t *testing.T) {
+	type Person struct{}
+
+	_, err := typesForStatement([]any{Person{}, sqlairtesting.Person{}})
+	assert.Error(t, err, NewErrTypeNameNotUnique("Person"))
+}
+
+func TestValidateExpressionTypesFullCoverage(t *testing.T) {
+	type address struct{}
+
+	argTypes, err := typesForStatement([]any{sqlairtesting.Person{}, address{}})
+	assert.Nil(t, err)
+
+	err = validateExpressionTypes(getExpression(), argTypes)
+	assert.Nil(t, err)
+}
+
+func TestValidateExpressionTypesMissingTypesError(t *testing.T) {
+	argTypes, err := typesForStatement([]any{sqlairtesting.Person{}})
+	assert.Nil(t, err)
+
+	err = validateExpressionTypes(getExpression(), argTypes)
+	assert.Error(t, err, NewErrTypeInfoNotPresent("address"))
+}
+
+func TestValidateExpressionTypesSuperfluousTypesError(t *testing.T) {
+	type address struct{}
+	type notUsed struct{}
+
+	argTypes, err := typesForStatement([]any{sqlairtesting.Person{}, address{}, notUsed{}})
+	assert.Nil(t, err)
+
+	err = validateExpressionTypes(getExpression(), argTypes)
+	assert.Error(t, err, NewErrSuperfluousType("notUsed"))
+}
+
+func getExpression() parse.Expression {
+	return &sqlairtesting.SimpleExpression{
+		T: parse.SQL,
+		E: []*sqlairtesting.SimpleExpression{
+			{
+				T: parse.OutputTarget,
+				E: []*sqlairtesting.SimpleExpression{
+					{},
+					{
+						T: parse.Identity,
+						S: "Person",
+					},
+				},
+			},
+			{
+				T: parse.InputSource,
+				E: []*sqlairtesting.SimpleExpression{
+					{},
+					{
+						T: parse.Identity,
+						S: "address",
+					},
+				},
+			},
+		},
+	}
+}

--- a/testing/expression.go
+++ b/testing/expression.go
@@ -1,0 +1,21 @@
+package testing
+
+import "github.com/canonical/sqlair/parse"
+
+// SimpleExpression is a minimal implementation of parse.Expression.
+type SimpleExpression struct {
+	T parse.ExpressionType
+	E []*SimpleExpression
+	S string
+}
+
+func (e *SimpleExpression) Type() parse.ExpressionType { return e.T }
+func (e *SimpleExpression) String() string             { return e.S }
+
+func (e *SimpleExpression) Expressions() []parse.Expression {
+	res := make([]parse.Expression, len(e.E))
+	for i, exp := range e.E {
+		res[i] = exp
+	}
+	return res
+}

--- a/testing/person.go
+++ b/testing/person.go
@@ -1,0 +1,7 @@
+package testing
+
+// Person is a simple test subject for inputs to sqlair.Prepare.
+type Person struct {
+	ID   string `db:"id"`
+	Name string `db:"name"`
+}


### PR DESCRIPTION
This patch adds a nascent form of the `sqlair.Prepare` function.

It has the following functionality:
- Parsing DSL into an Expression tree via the (currently stubbed) parser.
- Generating type information from any arguments.
- Ensuring that identity expressions for input/output args are represented in the type information.
- Ensuring that no redundant arguments are passed to `Prepare` for type information.

Peripheral changes include:
- Addition of a common testing package.
- Enhancement of the `parse.Info` (formerly `parse.Kind`) interface.
- Addition of custom error types.