### PR TITLE
[JUJU-1370] Add a Walk function for ranging over the expression tree

### DIFF
--- a/parse/ast.go
+++ b/parse/ast.go
@@ -54,3 +54,17 @@ type Expression interface {
 	// String returns the string that constitutes the expression.
 	String() string
 }
+
+// Walk recursively iterates depth-first over the input expression tree,
+// calling the input function. If it returns false, the iteration terminates.
+func Walk(parent Expression, visit func(Expression) bool) bool {
+	if !visit(parent) {
+		return false
+	}
+	for _, child := range parent.Expressions() {
+		if !Walk(child, visit) {
+			return false
+		}
+	}
+	return true
+}

--- a/parse/ast_test.go
+++ b/parse/ast_test.go
@@ -1,0 +1,62 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// testExp is a minimal implementation of Expression.
+type testExp struct {
+	t ExpressionType
+	e []*testExp
+}
+
+func (e *testExp) Type() ExpressionType { return e.t }
+func (e *testExp) String() string       { return "" }
+
+func (e *testExp) Expressions() []Expression {
+	res := make([]Expression, len(e.e))
+	for i, exp := range e.e {
+		res[i] = exp
+	}
+	return res
+}
+
+func TestWalk(t *testing.T) {
+	expr := &testExp{
+		t: SQL,
+		e: []*testExp{
+			{
+				t: InputSource,
+				e: []*testExp{
+					{
+						t: PassThrough,
+					},
+				},
+			},
+			{
+				t: Identity,
+			},
+			{
+				t: GroupedColumns,
+			},
+		},
+	}
+
+	var types []ExpressionType
+	visit := func(e Expression) bool {
+		if e.Type() == Identity {
+			return false
+		}
+		types = append(types, e.Type())
+		return true
+	}
+
+	finished := Walk(expr, visit)
+
+	// We expect to descend depth first into the expression tree,
+	// and stop at the `Identity` expression.
+	assert.False(t, finished)
+	assert.Equal(t, []ExpressionType{SQL, InputSource, PassThrough}, types)
+}


### PR DESCRIPTION
The walk function allows us to recurse into an expression tree, calling a specified function for each visited expression.

This will be used for compiling our DSL into a statement executable against the database.