### PR TITLE
lexer: Fix typo

### DIFF
--- a/parse/lexer.go
+++ b/parse/lexer.go
@@ -118,7 +118,7 @@ func (l *Lexer) readIdentifier() string {
 	return l.input[pos:l.offset]
 }
 
-// readNumber calls nextChar until it detects the end of a quoted string,
+// readString calls nextChar until it detects the end of a quoted string,
 // then returns the range of input from when we started reading.
 // The return includes the quotes.
 func (l *Lexer) readString(r rune) string {


### PR DESCRIPTION
s/readNumber/readString in the comment.